### PR TITLE
Fix access specifiers between CBS.h/ECBS.h

### DIFF
--- a/inc/CBS/CBS.h
+++ b/inc/CBS/CBS.h
@@ -137,9 +137,6 @@ protected:
 
 	int num_of_agents;
 
-
-
-	vector<Path> paths_found_initially;  // contain initial paths found
 	// vector<MDD*> mdds_initially;  // contain initial paths found
 	vector < SingleAgentSolver* > search_engines;  // used to find (single) agents' paths and mdd
 
@@ -159,6 +156,7 @@ protected:
 	// print and save
 	void printResults() const;
 	static void printConflicts(const HLNode &curr) ;
+	virtual void printPaths() const;
 
 	bool validateSolution() const;
 	inline int getAgentLocation(int agent_id, size_t timestep) const;
@@ -170,6 +168,8 @@ protected:
 
 private: // CBS only, cannot be used by ECBS
     CBSNode* goal_node = nullptr;
+
+	vector<Path> paths_found_initially;  // contain initial paths found
 
 	pairing_heap< CBSNode*, compare<CBSNode::compare_node_by_f> > cleanup_list; // it is called open list in ECBS
 	pairing_heap< CBSNode*, compare<CBSNode::compare_node_by_inadmissible_f> > open_list; // this is used for EES
@@ -185,6 +185,4 @@ private: // CBS only, cannot be used by ECBS
 	bool generateRoot();
 	bool findPathForSingleAgent(CBSNode*  node, int ag, int lower_bound = 0);
 	void classifyConflicts(CBSNode &parent);
-
-	void printPaths() const;
 };

--- a/inc/CBS/ECBS.h
+++ b/inc/CBS/ECBS.h
@@ -18,6 +18,7 @@ public:
 	ECBSNode* getGoalNode() { return goal_node; }
     void updatePaths(ECBSNode* curr);
 	void clear();
+	void printPaths() const;
 private:
     //ECBSNode* dummy_start = nullptr;
     ECBSNode* goal_node = nullptr;
@@ -43,7 +44,4 @@ private:
 	bool findPathForSingleAgent(ECBSNode*  node, int ag);
 	void classifyConflicts(ECBSNode &node);
 	void computeConflictPriority(shared_ptr<Conflict>& con, ECBSNode& node);
-
-	//update information
-	void printPaths() const;
 };


### PR DESCRIPTION
Calling `terminate()` on `ECBS` object caused a segfault because `terminate()` is implemented by the base class `CBS`. This method called `printPaths()` (from the base implementation) which caused the segfault since the member variable `paths_found_initially` from the base implementation was empty.

To make matters confusing, the base class had a protected variable `paths_found_initially` but the subclass "shadows" this variable by defining a private variable with the same
name (`paths_found_initially`) but a different type.

This change updates access specifiers to align with usage and prevent segfault when `CBS::terminate()` is called from a subclass.

Fixes #2